### PR TITLE
raise MixpanelException properly in `BufferedConsumer._flush_endpoint`

### DIFF
--- a/mixpanel/__init__.py
+++ b/mixpanel/__init__.py
@@ -466,7 +466,8 @@ class BufferedConsumer(object):
             try:
                 self._consumer.send(endpoint, batch_json)
             except MixpanelException as e:
-                e.message = 'batch_json'
+                e.batch_json = batch_json
                 e.endpoint = endpoint
+                raise e
             buf = buf[self._max_size:]
         self._buffers[endpoint] = buf


### PR DESCRIPTION
set `batch_json` as a property on the exception in case it needs to be dealt with
by the calling code
